### PR TITLE
pstress-69 Introduce new option exact-initial-records

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -129,6 +129,7 @@ struct Option {
     ANALYZE,
     TRUNCATE,
     DROP_CREATE,
+    EXACT_INITIAL_RECORDS,
     MAX
   } option;
   Option(Type t, Opt o, std::string n)

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -248,8 +248,18 @@ void add_options() {
 
   /* Initial Records in table */
   opt = newOption(Option::INT, Option::INITIAL_RECORDS_IN_TABLE, "records");
-  opt->help = "Number of initial records in table";
+  opt->help =
+      "Number of initial records (N) in each table. The table will have random "
+      "records in range of 0 to N. Also check --exact-initial-records ";
   opt->setInt(1000);
+
+  /* Initial Records in table */
+  opt = newOption(Option::BOOL, Option::EXACT_INITIAL_RECORDS,
+                  "exact-initial-records");
+  opt->help = " When passed with --records (N) option "
+              "inserts exact number of  N records in tables.";
+  opt->setBool(false);
+  opt->setArgs(no_argument);
 
   /* Execute workload for number of seconds */
   opt = newOption(Option::INT, Option::NUMBER_OF_SECONDS_WORKLOAD, "seconds");

--- a/src/random_test.cpp
+++ b/src/random_test.cpp
@@ -1709,7 +1709,9 @@ void load_default_data(Table *table, Thd1 *thd) {
   thd->ddl_query = false;
   static int initial_records =
       options->at(Option::INITIAL_RECORDS_IN_TABLE)->getInt();
-  int rec = rand_int(initial_records);
+  int rec = options->at(Option::EXACT_INITIAL_RECORDS)->getBool()
+                ? initial_records
+                : rand_int(initial_records);
   for (int i = 0; i < rec; i++) {
     table->InsertRandomRow(thd, false);
   }


### PR DESCRIPTION
Insert exact number of initial records mention with --records
Otherwise it randomly insert records in each table