### PR TITLE
pstress-74 Pstress generates syntactically incorrent queries

### DIFF
--- a/src/random_test.hpp
+++ b/src/random_test.hpp
@@ -68,7 +68,7 @@ public:
   /* return random value of that column */
   virtual std::string rand_value();
   /* return string to call type */
-  const std::string col_type_to_string(COLUMN_TYPES type) const;
+  static const std::string col_type_to_string(COLUMN_TYPES type);
   /* return column type from a string */
   COLUMN_TYPES col_type(std::string type);
   /* used to create_metadata */
@@ -117,7 +117,7 @@ struct Generated_Column : public Column {
 
   std::string str;
   std::string clause() { return str; };
-  std::string rand_value() { return "default"; };
+  std::string rand_value();
   ~Generated_Column(){};
   COLUMN_TYPES g_type; // sub type can be blob,int, varchar
   COLUMN_TYPES generate_type() { return g_type; };


### PR DESCRIPTION
Pstress generates syntactically incorrect queries because
One of the main reason is because it uses `default` keyword in the WHERE
clause.

Fixed the default error. now generated column uses  column type default
value