### PR TITLE
PSTRESS-77 Add support for keyring component in pstress

### DIFF
--- a/pstress/pstress-run-PXC57.conf
+++ b/pstress/pstress-run-PXC57.conf
@@ -170,6 +170,8 @@ THREADS=10
 # Start vault server for pstress encryption run.                               #
 ################################################################################
 WITH_KEYRING_VAULT=0
+KEYRING_PLUGIN="--early-plugin-load=keyring_file.so --keyring_file_data=keyring"
+KEYRING_COMPONENT=0
 
 # ==== PXC 8.0 example:
 MYEXTRA="--thread_handling=pool-of-threads --log-bin --server-id=0 --binlog_format=ROW --gtid_mode=ON --enforce_gtid_consistency=ON  --master_verify_checksum=on --binlog_checksum=CRC32"

--- a/pstress/pstress-run-PXC80.conf
+++ b/pstress/pstress-run-PXC80.conf
@@ -170,6 +170,8 @@ THREADS=10
 # Start vault server for pstress encryption run.                               #
 ################################################################################
 WITH_KEYRING_VAULT=0
+KEYRING_PLUGIN="--early-plugin-load=keyring_file.so --keyring_file_data=keyring"
+KEYRING_COMPONENT=1
 
 # ==== PXC 8.0 example:
 MYEXTRA="--thread_handling=pool-of-threads --log-bin --server-id=0 --binlog_format=ROW --gtid_mode=ON --enforce_gtid_consistency=ON  --master_verify_checksum=on --binlog_checksum=CRC32"

--- a/pstress/pstress-run.conf
+++ b/pstress/pstress-run.conf
@@ -140,12 +140,17 @@ QUERIES_PER_THREAD=100000
 # MYINIT="--early-plugin-load=keyring_file.so --keyring_file_data=keyring      #
 # --innodb_sys_tablespace_encrypt=ON"                                          #
 ################################################################################
-MYINIT="--early-plugin-load=keyring_file.so --keyring_file_data=keyring"
+MYINIT=
+MYEXTRA=
 
 ################################################################################
-# Extra options to pass to mysqld. Examples below                              #
+# Keyring options: Component and Plugin                                        #
+# Both are supported in MySQL from 8.0.24 onwards. However, we can use either  #
+# component or plugin at a time. By default component will be used with PS-8.0 #
+# For PS-5.7, keyring plugin will be used                                      #
 ################################################################################
-MYEXTRA="--early-plugin-load=keyring_file.so --keyring_file_data=keyring"
+KEYRING_PLUGIN="--early-plugin-load=keyring_file.so --keyring_file_data=keyring"
+KEYRING_COMPONENT=1
 
 ###############################################################################
 # 5.6/5.7                                                                     #


### PR DESCRIPTION
Problem: With the introduction of keyring components in MySQL 8.0.24, it is now
possible to use either plugin or component infrastructure for keyring encryption

Solution: Implemented an option to enable/disable keyring component.
For PS-5.7 runs, we will continue to use keyring plugin as components are unsupported
For PS-8.0 runs, by default components will be used for keyring encryption