### PR TITLE
pstress-92 pstress does not create step files if crash happens during…

### DIFF
--- a/src/random_test.cpp
+++ b/src/random_test.cpp
@@ -3041,7 +3041,9 @@ void Thd1::run_some_query() {
     ddl_query = true;
     Table *table = Table::table_id(Table::TEMPORARY, i, this);
     if (!execute_sql(table->definition(), this))
-      throw std::runtime_error("Create table failed " + table->name_);
+      thread_log << thread_id << " Error create table failed " << table->name_
+                 << std::endl;
+
     all_session_tables->push_back(table);
 
     /* load default data in temporary table */


### PR DESCRIPTION
… session table creation

Incase, pstress failed to create temporary table
log failure in log file instead of crashing.