### PR TITLE
PSTRESS-97 : Removal of valgrind code from Pstress

### DIFF
--- a/pstress/pstress-run-PXC57.conf
+++ b/pstress/pstress-run-PXC57.conf
@@ -92,7 +92,7 @@ PXC_MAX_NR_OF_RND_OPTS_TO_ADD=4
 # Save only trials that generate a core file (good for initial few runs where  #
 # there are lot of crashes/asserts)                                            #
 ################################################################################
-SAVE_TRIALS_WITH_CORE_OR_VALGRIND_ONLY=0
+SAVE_TRIALS_WITH_CORE=0
 
 ################################################################################
 # Saves per-trial SQL even if SAVE_TRIALS_WITH_CORE_OR_VALGRIND_ONLY=1.        #
@@ -177,14 +177,6 @@ MYSAFE="--no-defaults --max_allowed_packet=33554432 --maximum-bulk_insert_buffer
 # Number of threads to use. Default: 10.                                       #
 ################################################################################
 THREADS=10
-
-################################################################################
-# Set to 1 to make this a Valgrind run. Do not change VALGRIND_CMD unless you  #
-# fully understand the change being made.                                      #
-################################################################################
-VALGRIND_RUN=0
-VALGRIND_CMD="valgrind --suppressions=${BASEDIR}/mysql-test/valgrind.supp --num-callers=40 --show-reachable=yes --track-origins=yes"
-VALGRIND_ERRORS_FOUND=0
 
 ################################################################################
 # Set to 1 to make this a pxc pstress cluster run (enables multi-node SQL      #

--- a/pstress/pstress-run-PXC57.conf
+++ b/pstress/pstress-run-PXC57.conf
@@ -92,10 +92,10 @@ PXC_MAX_NR_OF_RND_OPTS_TO_ADD=4
 # Save only trials that generate a core file (good for initial few runs where  #
 # there are lot of crashes/asserts)                                            #
 ################################################################################
-SAVE_TRIALS_WITH_CORE=0
+SAVE_TRIALS_WITH_CORE_ONLY=0
 
 ################################################################################
-# Saves per-trial SQL even if SAVE_TRIALS_WITH_CORE_OR_VALGRIND_ONLY=1.        #
+# Saves per-trial SQL even if SAVE_TRIALS_WITH_CORE_ONLY=1.        #
 # Main usecase: full server lockups/hangs                                      #
 ################################################################################
 SAVE_SQL=0

--- a/pstress/pstress-run-PXC80.conf
+++ b/pstress/pstress-run-PXC80.conf
@@ -92,7 +92,7 @@ PXC_MAX_NR_OF_RND_OPTS_TO_ADD=4
 # Save only trials that generate a core file (good for initial few runs where  #
 # there are lot of crashes/asserts)                                            #
 ################################################################################
-SAVE_TRIALS_WITH_CORE_OR_VALGRIND_ONLY=0
+SAVE_TRIALS_WITH_CORE=0
 
 ################################################################################
 # Saves per-trial SQL even if SAVE_TRIALS_WITH_CORE_OR_VALGRIND_ONLY=1.        #
@@ -177,14 +177,6 @@ MYSAFE="--no-defaults --max_allowed_packet=33554432 --maximum-bulk_insert_buffer
 # Number of threads to use. Default: 10.                                       #
 ################################################################################
 THREADS=10
-
-################################################################################
-# Set to 1 to make this a Valgrind run. Do not change VALGRIND_CMD unless you  #
-# fully understand the change being made.                                      #
-################################################################################
-VALGRIND_RUN=0
-VALGRIND_CMD="valgrind --suppressions=${BASEDIR}/mysql-test/valgrind.supp --num-callers=40 --show-reachable=yes --track-origins=yes"
-VALGRIND_ERRORS_FOUND=0
 
 ################################################################################
 # Set to 1 to make this a pxc pstress cluster run (enables multi-node SQL      #

--- a/pstress/pstress-run-PXC80.conf
+++ b/pstress/pstress-run-PXC80.conf
@@ -92,10 +92,10 @@ PXC_MAX_NR_OF_RND_OPTS_TO_ADD=4
 # Save only trials that generate a core file (good for initial few runs where  #
 # there are lot of crashes/asserts)                                            #
 ################################################################################
-SAVE_TRIALS_WITH_CORE=0
+SAVE_TRIALS_WITH_CORE_ONLY=0
 
 ################################################################################
-# Saves per-trial SQL even if SAVE_TRIALS_WITH_CORE_OR_VALGRIND_ONLY=1.        #
+# Saves per-trial SQL even if SAVE_TRIALS_WITH_CORE_ONLY=1.        #
 # Main usecase: full server lockups/hangs                                      #
 ################################################################################
 SAVE_SQL=0

--- a/pstress/pstress-run-rocksdb.conf
+++ b/pstress/pstress-run-rocksdb.conf
@@ -107,10 +107,10 @@ ENGINE=RocksDB
 # Save only trials that generate a core file (good for initial few runs where  #
 # there are lot of crashes/asserts)                                            #
 ################################################################################
-SAVE_TRIALS_WITH_CORE_OR_VALGRIND_ONLY=0
+SAVE_TRIALS_WITH_CORE_ONLY=0
 
 ################################################################################
-# Saves per-trial SQL even if SAVE_TRIALS_WITH_CORE_OR_VALGRIND_ONLY=1.        #
+# Saves per-trial SQL even if SAVE_TRIALS_WITH_CORE_ONLY=1.        #
 # Main usecase: full server lockups/hangs                                      #
 ################################################################################
 SAVE_SQL=0

--- a/pstress/pstress-run.conf
+++ b/pstress/pstress-run.conf
@@ -95,7 +95,7 @@ MAX_NR_OF_RND_OPTS_TO_ADD=5
 # Save only trials that generate a core file (good for initial few runs where  #
 # there are lot of crashes/asserts)                                            #
 ################################################################################
-SAVE_TRIALS_WITH_CORE_OR_VALGRIND_ONLY=0
+SAVE_TRIALS_WITH_CORE=0
 
 ################################################################################
 # Saves per-trial SQL even if SAVE_TRIALS_WITH_CORE_OR_VALGRIND_ONLY=1.        #

--- a/pstress/pstress-run.conf
+++ b/pstress/pstress-run.conf
@@ -95,10 +95,10 @@ MAX_NR_OF_RND_OPTS_TO_ADD=5
 # Save only trials that generate a core file (good for initial few runs where  #
 # there are lot of crashes/asserts)                                            #
 ################################################################################
-SAVE_TRIALS_WITH_CORE=0
+SAVE_TRIALS_WITH_CORE_ONLY=0
 
 ################################################################################
-# Saves per-trial SQL even if SAVE_TRIALS_WITH_CORE_OR_VALGRIND_ONLY=1.        #
+# Saves per-trial SQL even if SAVE_TRIALS_WITH_CORE_ONLY=1.        #
 # Main usecase: full server lockups/hangs                                      #
 ################################################################################
 SAVE_SQL=0

--- a/pstress/pstress-run.sh
+++ b/pstress/pstress-run.sh
@@ -8,7 +8,7 @@
 CONFIGURATION_FILE=pstress-run.conf  # Do not use any path specifiers, the .conf file should be in the same path as pstress-run.sh
 
 # ========================================= Improvement ideas ====================================================================
-# * SAVE_TRIALS_WITH_CORE=0 (These likely include some of the 'SIGKILL' issues - no core but terminated)
+# * SAVE_TRIALS_WITH_CORE_ONLY=0 (These likely include some of the 'SIGKILL' issues - no core but terminated)
 # * SQL hashing s/t2/t1/, hex values "0x"
 # * Full MTR grammar on one-liners
 # * Interleave all statements with another that is likely to cause issues, for example "USE mysql"
@@ -1074,7 +1074,7 @@ EOF
     do
       kill_server $SIGNAL $i
     done
-    fi
+  fi
   if [ ${ISSTARTED} -eq 1 -a ${TRIAL_SAVED} -ne 1 ]; then  # Do not try and print pstress log for a failed mysqld start
     if [[ ${PXC} -eq 1 && ${PXC_CLUSTER_RUN} -eq 0 ]]; then
       echoit "pstress run details:$(grep -i 'SUMMARY.*queries failed' ${RUNDIR}/${TRIAL}/node1/*.sql ${RUNDIR}/${TRIAL}/node1/*.log | sed 's|.*:||')"
@@ -1144,8 +1144,8 @@ EOF
       echoit "ASAN issue detected in the mysqld error log for this trial; saving this trial"
       savetrial
       TRIAL_SAVED=1
-    elif [ ${SAVE_TRIALS_WITH_CORE} -eq 0 ]; then
-      echoit "Saving full trial outcome (as SAVE_TRIALS_WITH_CORE=0 and so trials are saved irrespective of whether an issue was detected or not)"
+    elif [ ${SAVE_TRIALS_WITH_CORE_ONLY} -eq 0 ]; then
+      echoit "Saving full trial outcome (as SAVE_TRIALS_WITH_CORE_ONLY=0 and so trials are saved irrespective of whether an issue was detected or not)"
       savetrial
       TRIAL_SAVED=1
     elif [ ${TRIAL} -gt 1 ]; then
@@ -1167,7 +1167,10 @@ EOF
       CRASH_CHECK=0
     else
       if [ ${SAVE_SQL} -eq 1 ]; then
+	echoit "Not saving anything for this trial (as SAVE_TRIALS_WITH_CORE_ONLY=1, and no issue was seen), except the SQL trace (as SAVE_SQL=1)"
         savesql
+      else
+	echoit "Not saving anything for this trial (as SAVE_TRIALS_WITH_CORE_ONLY=1 and SAVE_SQL=0, and no issue was seen)"
       fi
     fi
   fi
@@ -1236,7 +1239,7 @@ if [[ $WITH_KEYRING_VAULT -eq 1 ]];then
   fi
 fi
 
-echoit "mysqld Start Timeout: ${MYSQLD_START_TIMEOUT} | Client Threads: ${THREADS} | Queries/Thread: ${QUERIES_PER_THREAD} | Trials: ${TRIALS} | Save coredump issue trials only: `if [ ${SAVE_TRIALS_WITH_CORE} -eq 1 ]; then echo -n 'TRUE'; if [ ${SAVE_SQL} -eq 1 ]; then echo ' + save all SQL traces'; else echo ''; fi; else echo 'FALSE'; fi`"
+echoit "mysqld Start Timeout: ${MYSQLD_START_TIMEOUT} | Client Threads: ${THREADS} | Queries/Thread: ${QUERIES_PER_THREAD} | Trials: ${TRIALS} | Save coredump issue trials only: `if [ ${SAVE_TRIALS_WITH_CORE_ONLY} -eq 1 ]; then echo -n 'TRUE'; if [ ${SAVE_SQL} -eq 1 ]; then echo ' + save all SQL traces'; else echo ''; fi; else echo 'FALSE'; fi`"
 
 echoit "Storage Engine: ${ENGINE}"
 SQL_INPUT_TEXT="SQL file used: ${INFILE}"

--- a/pstress/pstress-run.sh
+++ b/pstress/pstress-run.sh
@@ -776,7 +776,7 @@ EOF
     PORT=$[50000 + ( $RANDOM % ( 9999 ) ) ]
     echoit "Starting mysqld. Error log is stored at ${RUNDIR}/${TRIAL}/log/master.err"
     CMD="${BIN} ${MYSAFE} ${MYEXTRA} ${KEYRING_PLUGIN} --basedir=${BASEDIR} --datadir=${RUNDIR}/${TRIAL}/data \
-	--tmpdir=${RUNDIR}/${TRIAL}/tmp --core-file --port=$PORT --pid_file=${RUNDIR}/${TRIAL}/pid.pid --socket=${SOCKET} \
+        --tmpdir=${RUNDIR}/${TRIAL}/tmp --core-file --port=$PORT --pid_file=${RUNDIR}/${TRIAL}/pid.pid --socket=${SOCKET} \
         --log-output=none --log-error-verbosity=3 --log-error=${RUNDIR}/${TRIAL}/log/master.err"
     echo $CMD
     $CMD > ${RUNDIR}/${TRIAL}/log/master.err 2>&1 &
@@ -1167,10 +1167,10 @@ EOF
       CRASH_CHECK=0
     else
       if [ ${SAVE_SQL} -eq 1 ]; then
-	echoit "Not saving anything for this trial (as SAVE_TRIALS_WITH_CORE_ONLY=1, and no issue was seen), except the SQL trace (as SAVE_SQL=1)"
+        echoit "Not saving anything for this trial (as SAVE_TRIALS_WITH_CORE_ONLY=1, and no issue was seen), except the SQL trace (as SAVE_SQL=1)"
         savesql
       else
-	echoit "Not saving anything for this trial (as SAVE_TRIALS_WITH_CORE_ONLY=1 and SAVE_SQL=0, and no issue was seen)"
+        echoit "Not saving anything for this trial (as SAVE_TRIALS_WITH_CORE_ONLY=1 and SAVE_SQL=0, and no issue was seen)"
       fi
     fi
   fi


### PR DESCRIPTION
Removing valgrind code from PSTRESS because of below mentioned reasons.

Valgrind runs are extremely slow (30 mins just for starting+stopping server)
Single node startup takes 200+ seconds. a 3 node PXC cluster takes 15 mins just to start
There are shutdown timeout issues
Valgrind runs cannot be used for crash recovery testing as it requires slow shutdown to fetch full valgrind report.