### PR TITLE
PSTRESS-99 pstress must disable auto increment if indexes are disabled

### DIFF
--- a/src/random_test.cpp
+++ b/src/random_test.cpp
@@ -1526,6 +1526,10 @@ Table *Table::table_id(TABLE_TYPES type, int id, Thd1 *thd) {
   static auto engine = options->at(Option::ENGINE)->getString();
   table->engine = engine;
 
+  /* If indexes are disabled, also disable auto_inc */
+  if (!options->at(Option::INDEXES)->getInt())
+    options->at(Option::NO_AUTO_INC)->setBool(true);
+
   table->CreateDefaultColumn();
   table->CreateDefaultIndex();
 


### PR DESCRIPTION
Problem: If --indexes=0 is set for creating load in pstress, it was noticed
that the table creation was failing with the following error:

Incorrect table definition; there can be only one auto column and it must be defined as a key

Solution: Disable auto increment when there are no indexes used.