### PR TITLE
PSTRESS-102 Disable table compression on MacOS

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -4,6 +4,7 @@
 #ifndef PQVERSION
 #define PQVERSION "1"
 #endif
+
 #ifdef MAXPACKET
   #ifndef MAX_PACKET_DEFAULT
   #define MAX_PACKET_DEFAULT 4194304
@@ -17,6 +18,13 @@
 #ifndef PQREVISION
 #define PQREVISION "unknown"
 #endif
+
+#ifdef __APPLE__
+#define PLATFORM_ID "Darwin"
+#else
+#define PLATFORM_ID "Linux"
+#endif
+
 #include <getopt.h>
 #include <atomic>
 #include <map>

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -169,6 +169,9 @@ void Node::tryConnect() {
     server_version = mysql_get_server_info(conn);
   }
   general_log << "- Connected server version: " << server_version << std::endl;
+  if (strcmp(PLATFORM_ID,"Darwin") == 0)
+    general_log << "- Table compression is disabled as hole punching is not supported on OSX"
+                << std::endl;
   if (result != NULL) {
     mysql_free_result(result);
   }

--- a/src/random_test.cpp
+++ b/src/random_test.cpp
@@ -202,6 +202,10 @@ int sum_of_all_options(Thd1 *thd) {
     opt_int_set(ALTER_DATABASE_ENCRYPTION, 0);
   }
 
+  /* If OS is Mac, disable table compression as hole punching is not supported on OSX */
+  if (strcmp(PLATFORM_ID, "Darwin") == 0)
+    options->at(Option::NO_TABLE_COMPRESSION)->setBool(true);
+
   /* If no-table-compression is set, disable all compression */
   if (options->at(Option::NO_TABLE_COMPRESSION)->getBool()) {
     opt_int_set(ALTER_TABLE_COMPRESSION, 0);


### PR DESCRIPTION
     PSTRESS-102 Disable table compression on MacOS

    https://jira.percona.com/browse/PSTRESS-102

    Problem:
    As per MySQL documentation: https://dev.mysql.com/doc/refman/5.7/en/innodb-page-compression.html
    Hole punching is not supported on OSX. During pstress runs, below mentioned error is seen as table compression
    is enabled by default for creating the load.

    "Punch hole not supported by the filesystem or the tablespace page size is not large enough."

    Solution:
    Table compression is disabled on OSX