### PR TITLE
PSTRESS-101 alter-lock option is not generating proper queries

### DIFF
--- a/src/help.cpp
+++ b/src/help.cpp
@@ -177,16 +177,19 @@ void add_options() {
   opt->setInt(7);
 
   /* algorithm for alter */
-  opt = newOption(Option::STRING, Option::ALGORITHM, "alter-algorith");
-  opt->help = "algorithm used in alter table. INPLACE|COPY|DEFAULT\n all "
-              "means randomly one of them will be picked";
+  opt = newOption(Option::STRING, Option::ALGORITHM, "alter-algorithm");
+  opt->help = "algorithm used in alter table.\n"
+              "--alter-algorithm INPLACE,COPY,DEFAULT\n --alter-algorithm all "
+              "means randomly one of them will be picked. Pass options comma "
+              "seperated without space";
   opt->setString("all");
 
   /* lock for alter */
   opt = newOption(Option::STRING, Option::LOCK, "alter-lock");
   opt->help = "lock mechanism used in alter table.\n "
-              "DEFAULT|NONE|SHARED|EXCLUSIVE.\n all means randomly one of them "
-              "will be picked";
+              "--alter-lock DEFAULT,NONE,SHARED,EXCLUSIVE\n --alter-lock all "
+              "means randomly one of them will be picked. Pass options comma "
+              "seperated without space";
   opt->setString("all");
 
   /* Number of columns in a table */

--- a/src/random_test.cpp
+++ b/src/random_test.cpp
@@ -329,22 +329,29 @@ inline static std::string pick_algorithm_lock() {
   std::string current_algo;
 
   current_lock = locks[rand_int(locks.size() - 1)];
-
-/* With LOCK=NONE, ALGORITHM=INSTANT/COPY is not supported */
-  if (current_lock == "NONE") {
-    if (std::count(algorithms.begin(), algorithms.end(), "INSTANT"))
-      algorithms.erase(std::find(algorithms.begin(), algorithms.end(), "INSTANT"));
-    if (std::count(algorithms.begin(), algorithms.end(), "COPY"))
-      algorithms.erase(std::find(algorithms.begin(), algorithms.end(), "COPY"));
-  }
-/* With LOCK=EXCLUSIVE,DEFAULT,SHARED; ALGORITHM=INSTANT is not supported */
-  else if (current_lock == "EXCLUSIVE" || current_lock == "DEFAULT" || current_lock == "SHARED") {
-    if (std::count(algorithms.begin(), algorithms.end(), "INSTANT"))
-      algorithms.erase(std::find(algorithms.begin(), algorithms.end(), "INSTANT"));
-  }
-
   current_algo = algorithms[rand_int(algorithms.size() - 1)];
 
+  /*
+  Support Matrix	LOCK=DEFAULT	LOCK=EXCLUSIVE	LOCK=NONE	LOCK=SHARED
+  ALGORITHM=INPLACE	Supported	Supported	Supported	Supported
+  ALGORITHM=COPY	Supported	Supported	Not Supported	Supported
+  ALGORITHM=INSTANT	Supported	Not Supported	Not Supported	Not Supported
+  ALGORITHM=DEFAULT	Supported	Supported	Supported	Supported
+*/
+
+  /* If current_algo=INPLACE|DEFAULT, do nothing, since all lock types supported */
+  if (current_algo == "INSTANT")
+    current_lock = "DEFAULT";
+  else if (current_algo == "COPY") {
+    int a = rand_int(2);
+    std::cout << "value a:" << a << std::endl;
+    if (a == 0)
+      current_lock = "DEFAULT";
+    else if (a == 1)
+      current_lock = "EXCLUSIVE";
+    else
+      current_lock = "SHARED";
+  }
   return " LOCK=" + current_lock + ", ALGORITHM=" + current_algo;
 }
 


### PR DESCRIPTION
    PSTRESS-101 alter-lock option is not generating proper queries

    https://jira.percona.com/browse/PSTRESS-101

    Problem:
    Currently, comma seperated options for --alter-lock or --alter-algorithm is not supported.
    The user could either pass the value as "all" which would pick all supported options randomly or
    pass individual values.

    Solution:
    1.Added supported for passing options comma seperated without space
     --alter-lock NONE,SHARED,EXCLUSIVE
     --alter-algorithm INPLACE,COPY,INSTANT

    2.Added checks to improve ALTER LOCK queries