### PR TITLE
Disable unsupported features in pxc 5.7 when encryption is enabled

### DIFF
--- a/pstress/pstress-run-PXC57.conf
+++ b/pstress/pstress-run-PXC57.conf
@@ -20,7 +20,7 @@ PSTRESS_BIN=${SCRIPT_PWD}/../src/pstress-pxc
 # executed. Default options added.                                             #
 # Please modify the parameters as per needs before starting the runs.          #
 ################################################################################
-DYNAMIC_QUERY_PARAMETER="--tables 5 --records 100 --log-all-queries --log-failed-queries --no-encryption"
+DYNAMIC_QUERY_PARAMETER="--tables 5 --records 100 --log-all-queries --log-failed-queries"
 
 ################################################################################
 # Random seed to create the metadata. If not set, random value will be picked. #
@@ -164,7 +164,7 @@ KEYRING_COMPONENT=1
 # 2. In case ENCRYPTION_RUN is enabled, please remove "--no-encryption" from   #
 # DYNAMIC_QUERY_PARAMETER to allow generating SQL queries with ENCRYPTION=Y|N  #
 ################################################################################
-ENCRYPTION_RUN=0
+ENCRYPTION_RUN=1
 
 ###############################################################################
 # 5.6/5.7                                                                     #

--- a/pstress/pstress-run.sh
+++ b/pstress/pstress-run.sh
@@ -329,8 +329,10 @@ if [[ $PXC -eq 1 ]];then
     echo "enforce_gtid_consistency=ON" >> ${BASEDIR}/my.cnf
     echo "master_verify_checksum=on" >> ${BASEDIR}/my.cnf
     echo "binlog_checksum=CRC32" >> ${BASEDIR}/my.cnf
-    echo "binlog_encryption=ON" >> ${BASEDIR}/my.cnf
     echo "pxc_encrypt_cluster_traffic=ON" >> ${BASEDIR}/my.cnf
+    if check_for_version $MYSQL_VERSION "8.0.0" ; then
+      echo "binlog_encryption=ON" >> ${BASEDIR}/my.cnf
+    fi
     if [[ $WITH_KEYRING_VAULT -ne 1 ]];then
       echo "early-plugin-load=keyring_file.so" >> ${BASEDIR}/my.cnf
       echo "keyring_file_data=keyring" >> ${BASEDIR}/my.cnf


### PR DESCRIPTION
Problem : When we execute pstress for PXC 5.7 , it throws an error [ERROR]unknown variable 'binlog_encryption=ON'

Fix : As binlog encryption is not supported for PXC 5.7 , so added a PXC version check in driver script to check for version before adding this variable.