### PR TITLE
PSTRESS-113 - Implement a script that converts pstress logs into SQL …

### DIFF
--- a/pstress/pstress_log_to_sql_converter.sh
+++ b/pstress/pstress_log_to_sql_converter.sh
@@ -9,8 +9,8 @@
 # Usage   :                                                                                   #
 # ./pstress_log_to_sql_converter.sh default.node.tld_step_1_thread-0.sql                      #
 #                                                                                             #
-# Update the BASEDIR and SOCKET information of the running server before executing the script #
-# eg. BASEDIR=$HOME/mysql-8.0/bld_8.0.28/install                                              #
+# Update the BUILD_DIR & SOCKET information of the running server before executing the script #
+# eg. BUILD_DIR=$HOME/mysql-8.0/bld_8.0.28/                                                   #
 #     SOCKET=/tmp/mysql_22000.sock                                                            #
 ###############################################################################################
 
@@ -53,10 +53,18 @@ echo "Converted SQL file can be found here: $outputFileName"
 # 1. Make sure to start a fresh MySQL instance before running this script. Executing the SQL file on an already #
 #    running server may have existing database objects (eg. general tablespaces, tables, etc) causing failures. #
 #################################################################################################################
-# To Execute SQLs against a running server set the BASEDIR and SOCKET path (Optional).
-BASEDIR=
+# To Execute SQLs against a running server set the BUILD_DIR and SOCKET path (Optional).
+BUILD_DIR=
 SOCKET=
-if [[ $BASEDIR != "" && $SOCKET != "" ]]; then
-  $BASEDIR/bin/mysql -uroot -S$SOCKET -e "source $outputFileName"
-fi
+if [[ $BUILD_DIR != "" && $SOCKET != "" ]]; then
+  $BUILD_DIR/runtime_output_directory/mysql -uroot -S$SOCKET -e "source $outputFileName"
 
+  if [ $? -eq 0 ]; then
+    echo "Query execution successful. Check server logs for details"
+  else
+    echo "There is a failure while executing SQLs. Please check, if
+  1. Server is running.
+  2. You are using a stale server. In that case, please remove old datadir, and start a new server.
+  3. The server has crashed while executing the SQLs. This is mostly a bug, please check server logs for details."
+  fi
+fi

--- a/pstress/pstress_log_to_sql_converter.sh
+++ b/pstress/pstress_log_to_sql_converter.sh
@@ -1,0 +1,56 @@
+###############################################################################################
+#                                                                                             #
+# Author  :  Mohit Joshi                                                                      #
+# Script  :  pstress_log_to_sql_converter.sh                                                  #
+# Created :  05-May-2022                                                                      #
+# Purpose :  The script is used to process pstress thread logs to filter out                  #
+#            SQLs from it                                                                     #
+#                                                                                             #
+# Usage   :                                                                                   #
+# ./pstress_log_to_sql_converter.sh default.node.tld_step_1_thread-0.sql                      #
+#                                                                                             #
+# Update the BASEDIR and SOCKET information of the running server before executing the script #
+#                                                                                             #
+###############################################################################################
+
+logFileName=$1
+
+SCRIPT=$(readlink -f $0)
+SCRIPT_PATH=`dirname $SCRIPT`
+outputFileName=$SCRIPT_PATH/reduced.sql
+
+echo "Reading the pstress logfile: $logFileName"
+
+# Filtering out all the successfully executed SQLs from the pstress log
+sed -n 's/.* S //p' $logFileName > $outputFileName
+
+# Trimming off un-necessary information at the beginning of each SQL
+sed -i 's/^ S //g' $outputFileName
+
+# Trimming off un-necessary information at the end of each SQL
+sed -i 's/rows:[0-9]*//g' $outputFileName
+
+# Find the crashing query
+crashQuery=$(awk '/Error Lost connection to MySQL server during query/{print prev} {prev=$0}' $logFileName | head -n1 | sed 's/.* F //')
+
+# Append the crashing query at the end of output file
+echo $crashQuery >> $outputFileName
+
+# Adding semi-colon at the end of each SQL statement. In case, semi-colon
+# already exists, then do not add twice
+sed -i '/[^;] *$/s/$/;/' $outputFileName
+
+echo "Converted SQL file can be found here: $outputFileName"
+
+#################################################################################################################
+# NOTE:                                                                                                         #
+# 1. Make sure to start a fresh MySQL instance before running this script. Executing the SQL file on an already #
+#    running server may have existing database objects (eg. general tablespaces, tables, etc) causing failures. #
+# 2. Comment SQL execution section(below) in case pstress logs are generated in multi-threaded mode. Reason     #
+#    being that, some database objects might be created in another thread causing SQLs to fail.                 #
+#################################################################################################################
+# Executing SQLs against a running server (Optional)
+BASEDIR=$HOME/mysql-8.0/bld_8.0.28/install
+SOCKET=/tmp/mysql_22000.sock
+$BASEDIR/bin/mysql -uroot -S$SOCKET -e "source $outputFileName"
+

--- a/pstress/pstress_log_to_sql_converter.sh
+++ b/pstress/pstress_log_to_sql_converter.sh
@@ -25,6 +25,7 @@ Help() {
   echo "--logfile: Full path to the pstress log file"
   echo "--mysql-client: Path to MySQL client"
   echo "--socket: Path to socket file to connect to running server"
+  echo "--user: Database username. If not provided, it defaults to root user"
 }
 
 if [ "$#" -eq 0 ]; then

--- a/pstress/pstress_log_to_sql_converter.sh
+++ b/pstress/pstress_log_to_sql_converter.sh
@@ -36,6 +36,7 @@ ARGUMENT_LIST=(
     "logfile"
     "mysql-client"
     "socket"
+    "user"
     "help"
 )
 
@@ -46,6 +47,11 @@ opts=$(getopt \
     --options "" \
     -- "$@"
 )
+
+if [ $? -ne 0 ]; then
+  echo "Invalid option. Exiting..."
+  exit 1
+fi
 
 eval set --$opts
 
@@ -58,27 +64,25 @@ while true; do
     --mysql-client)
 	shift
 	MYSQL=$1
-	break
 	;;
     --socket)
 	shift
 	SOCKET=$1
-	break
 	;;
     --logfile)
         shift
 	LOG_FILENAME=$1
-	break
+	;;
+    --user)
+	shift
+	USER_NAME=$1
 	;;
     --)
-	shift
-	Help
-	exit
+	break
 	;;
     esac
     shift
 done
-
 
 if [ ! -s $LOG_FILENAME ]; then
   echo "Input File $LOG_FILENAME is empty or does not exist. Exiting..."
@@ -120,7 +124,8 @@ echo "Converted SQL file can be found here: $OUTPUT_FILENAME"
 #################################################################################################################
 # To Execute SQLs against a running server set the MYSQL and SOCKET path (Optional).
 if [[ $MYSQL != "" && $SOCKET != "" ]]; then
-  $MYSQL -uroot -S$SOCKET -e "source $OUTPUT_FILENAME"
+  if [ "$USER_NAME" == "" ]; then USER_NAME=root; fi
+  $MYSQL -u$USER_NAME -p -S$SOCKET -e "source $OUTPUT_FILENAME"
 
   if [ $? -eq 0 ]; then
     echo "Query execution successful. Check server logs for details"

--- a/pstress/pstress_log_to_sql_converter.sh
+++ b/pstress/pstress_log_to_sql_converter.sh
@@ -10,10 +10,16 @@
 # ./pstress_log_to_sql_converter.sh default.node.tld_step_1_thread-0.sql                      #
 #                                                                                             #
 # Update the BASEDIR and SOCKET information of the running server before executing the script #
-#                                                                                             #
+# eg. BASEDIR=$HOME/mysql-8.0/bld_8.0.28/install                                              #
+#     SOCKET=/tmp/mysql_22000.sock                                                            #
 ###############################################################################################
 
 logFileName=$1
+
+if [ ! -s $logFileName ]; then
+  echo "Input File $logFileName is empty or does not exist. Exiting..."
+  exit 1
+fi
 
 SCRIPT=$(readlink -f $0)
 SCRIPT_PATH=`dirname $SCRIPT`
@@ -46,11 +52,11 @@ echo "Converted SQL file can be found here: $outputFileName"
 # NOTE:                                                                                                         #
 # 1. Make sure to start a fresh MySQL instance before running this script. Executing the SQL file on an already #
 #    running server may have existing database objects (eg. general tablespaces, tables, etc) causing failures. #
-# 2. Comment SQL execution section(below) in case pstress logs are generated in multi-threaded mode. Reason     #
-#    being that, some database objects might be created in another thread causing SQLs to fail.                 #
 #################################################################################################################
-# Executing SQLs against a running server (Optional)
-BASEDIR=$HOME/mysql-8.0/bld_8.0.28/install
-SOCKET=/tmp/mysql_22000.sock
-$BASEDIR/bin/mysql -uroot -S$SOCKET -e "source $outputFileName"
+# To Execute SQLs against a running server set the BASEDIR and SOCKET path (Optional).
+BASEDIR=
+SOCKET=
+if [[ $BASEDIR != "" && $SOCKET != "" ]]; then
+  $BASEDIR/bin/mysql -uroot -S$SOCKET -e "source $outputFileName"
+fi
 

--- a/pstress/pstress_log_to_sql_converter.sh
+++ b/pstress/pstress_log_to_sql_converter.sh
@@ -7,8 +7,12 @@
 #            SQLs from it                                                                     #
 #                                                                                             #
 # Usage   :                                                                                   #
+# 1. The user can pass the path of pstress log file as shown below to convert it in SQL file  #
 # ./pstress_log_to_sql_converter.sh --logdir <val>                                            #
-# ./pstress_log_to_sql_converter.sh --logdir <val> --build-dir <val> --socket <val>           #
+#                                                                                             #
+# 2. The user can use this script to also execute the converted SQL file against a running    #
+# server by setting the path --mysql-client and --socket                                      #
+# ./pstress_log_to_sql_converter.sh --logdir <val> --mysql-client <val> --socket <val>        #
 #                                                                                             #
 # For more info:                                                                              #
 # ./pstress_run_log_to_sql_converter.sh --help                                                #
@@ -16,9 +20,10 @@
 
 # Helper Function
 Help() {
-  echo "usage:  $BASH_SOURCE --logfile <val> --build-dir <val> --socket <val>"
+  echo "usage: $BASH_SOURCE --logfile <val>"
+  echo "usage: $BASH_SOURCE --logfile <val> --mysql-client <val> --socket <val>"
   echo "--logfile: Full path to the pstress log file"
-  echo "--build-dir: Path to MySQL build/installation directory"
+  echo "--mysql-client: Path to MySQL client"
   echo "--socket: Path to socket file to connect to running server"
 }
 
@@ -29,7 +34,7 @@ fi
 
 ARGUMENT_LIST=(
     "logfile"
-    "build-dir"
+    "mysql-client"
     "socket"
     "help"
 )
@@ -50,9 +55,9 @@ while true; do
         Help
         exit
         ;;
-    --build-dir)
+    --mysql-client)
 	shift
-	BUILD_DIR=$1
+	MYSQL=$1
 	break
 	;;
     --socket)
@@ -113,9 +118,8 @@ echo "Converted SQL file can be found here: $OUTPUT_FILENAME"
 # 1. Make sure to start a fresh MySQL instance before running this script. Executing the SQL file on an already #
 #    running server may have existing database objects (eg. general tablespaces, tables, etc) causing failures. #
 #################################################################################################################
-# To Execute SQLs against a running server set the BUILD_DIR and SOCKET path (Optional).
-if [[ $BUILD_DIR != "" && $SOCKET != "" ]]; then
-  MYSQL=$(find $BUILD_DIR -type f -name mysql | head -n1)
+# To Execute SQLs against a running server set the MYSQL and SOCKET path (Optional).
+if [[ $MYSQL != "" && $SOCKET != "" ]]; then
   $MYSQL -uroot -S$SOCKET -e "source $OUTPUT_FILENAME"
 
   if [ $? -eq 0 ]; then

--- a/src/random_test.cpp
+++ b/src/random_test.cpp
@@ -3055,7 +3055,7 @@ void clean_up_at_end() {
 void create_database_tablespace(Thd1 *thd) {
 
   /* drop database test*/
-  execute_sql("DROP DATABASE test", thd);
+  execute_sql("DROP DATABASE IF EXISTS test", thd);
   execute_sql("CREATE DATABASE test", thd); // todo encrypt database/schema
 
   for (auto &tab : g_tablespace) {


### PR DESCRIPTION
…file

The script will be helpful in case we find a crash with pstress in single-thread mode. It will filter out SQLs
from the pstress thread logs and store it in a file called reduced.sql.

If a server is running, passing the socket information to the script will execute the SQL file sequentially against
a running server.
Script name: pstress_log_to_sql_converter.sh
Output File: reduced.sql
Usage:
./pstress_log_to_sql_converter.sh default.node.tld_step_1_thread-0.sql