### PR TITLE
pstress-115 add support for AFTER in add columns

### DIFF
--- a/src/random_test.cpp
+++ b/src/random_test.cpp
@@ -82,7 +82,7 @@ static int get_server_version() {
  Example 8.0.26 -> 80026
  Example 5.7.35 -> 50735
 */
-int server_version() {
+static int server_version() {
   static int sv = get_server_version();
   return sv;
 }


### PR DESCRIPTION
AFTER clause is added for algo default and copy.
or in case of instant/inplace only if table doesn't have generated
column or compressed