### PR TITLE
pstress-78 Add support for generated virtual column queries in pstress

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -145,6 +145,7 @@ struct Option {
     CHAR_LENGTH,
     VARCHAR_LENGTH,
     BLOB_LENGTH,
+    DESC_INDEXES_IN_COLUMN,
     MAX
   } option;
   Option(Type t, Opt o, std::string n)

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -248,6 +248,11 @@ void add_options() {
   opt->setBool(false);
   opt->setArgs(no_argument);
 
+  /* Number of columns in an index of a table */
+  opt = newOption(Option::INT, Option::DESC_INDEXES_IN_COLUMN, "desc-prob");
+  opt->help = "probability of using desc in index";
+  opt->setInt(34);
+
   /* Only Partition tables */
   opt =
       newOption(Option::BOOL, Option::ONLY_PARTITION, "only-partition-tables");

--- a/src/random_test.hpp
+++ b/src/random_test.hpp
@@ -26,7 +26,6 @@
 #define MIN_SEED_SIZE 10000
 #define MAX_SEED_SIZE 100000
 #define MAX_RANDOM_STRING_SIZE 32
-#define DESC_INDEXES_IN_COLUMN 34
 #define MYSQL_8 8.0
 
 #define opt_int(a) options->at(Option::a)->getInt();
@@ -34,6 +33,8 @@
 #define opt_bool(a) options->at(Option::a)->getBool();
 #define opt_string(a) options->at(Option::a)->getString()
 
+class Column;
+typedef std::vector<Column *> Columns;
 int rand_int(int upper, int lower = 0);
 std::string rand_float(float upper, float lower = 0);
 std::string rand_double(double upper, double lower = 0);
@@ -218,7 +219,7 @@ struct Table {
   std::string encryption = "N";
   int key_block_size = 0;
   // std::string data_directory; todo add corressponding code
-  std::vector<Column *> *columns_;
+  Columns *columns_;
   std::vector<Index *> *indexes_;
   std::mutex table_mutex;
 


### PR DESCRIPTION
https://jira.percona.com/browse/PSTRESS-78

pstress-119 Option to manipulate length of CHAR, VARCHAR, BLOB
https://jira.percona.com/browse/PSTRESS-119

Introduced below new options

--columns-in-generated: maximum number of columns in a generated column
 default#: 6

--generated-stored: Probability of generated columns STORED or VIRTUAL
50 ==> equal chances of stored and virtual
100 => all columns are stored
0 => all columns are virtual
any other value sets the probability of stored column accordingly
default#: 50

--char-length: char column maximum length
 default#: 20

--varchar-length: varchar column maximum length.
 default#: 40

--blob-length: Maximum lenght of blob/text columns
TINYBLOB/TINYTEXT 1/4 of blob-length
TEXT/BLOB 1/3 of blob-length
MEDIUMBLOB/MEDIUMTEXT 1/2 of blob-length
LONGBLOB/LONGTEXT blob-length
 default#: 1000