### PR TITLE
pstress-122 pstress option --primary-key-probability 100 does not ens…

### DIFF
--- a/src/random_test.cpp
+++ b/src/random_test.cpp
@@ -1961,7 +1961,8 @@ void Table::DropColumn(Thd1 *thd) {
 
   auto name = columns_->at(ps)->name_;
 
-  if (name.compare("pkey") == 0 || name.compare("pkey_rename") == 0) {
+  if (rand_int(100, 1) <= options->at(Option::PRIMARY_KEY)->getInt() &&
+      name.find("pkey") != std::string::npos) {
     table_mutex.unlock();
     return;
   }


### PR DESCRIPTION
…ure tables have PK after drop+create table

https://jira.percona.com/browse/PSTRESS-122

drop primary key based on the primary-key-probability. i.e. If it is 100 do
not drop the primary key