### PR TITLE
PSTRESS-124: Improper cleanup in Node::tryConnect() results in error

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -176,6 +176,7 @@ void Node::tryConnect() {
     mysql_free_result(result);
   }
   mysql_close(conn);
+  mysql_thread_end();
   if (options->at(Option::TEST_CONNECTION)->getBool()) {
     exit(EXIT_SUCCESS);
   }

--- a/src/pstress.cpp
+++ b/src/pstress.cpp
@@ -184,7 +184,7 @@ int main(int argc, char *argv[]) {
   clean_up_at_end();
   mysql_library_end();
   delete_options();
-  std::cout << "COMPLTED" << std::endl;
+  std::cout << "COMPLETED" << std::endl;
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
https://jira.percona.com/browse/PSTRESS-124

Improper cleanup in Node::tryConnect() resulted in error when pstress is
shutting down.

    [ERROR] Error in my_thread_global_end(): 3 thread(s) did not exit.

Node::tryConnect() function increments the thread count upon successful
connection, but never decrements the count upon exit, thereby causing
the `my_thread_global_end()` function to error out with the above
mentioned message. This has been fixed now.

Also, fixes the typo in the exit status message.