### PR TITLE
follow up fix pstress-122 pstress option --primary-key-probability 100 does not ensure tables

### DIFF
--- a/src/random_test.cpp
+++ b/src/random_test.cpp
@@ -1350,10 +1350,9 @@ void Table::CreateDefaultColumn() {
     Column::COLUMN_TYPES type;
     Column *col;
     /*  if we need to create primary column */
-    static int pkey_pb_per_table = opt_int(PRIMARY_KEY);
 
     /* First column can be primary */
-    if (i == 0 && rand_int(100) < pkey_pb_per_table) {
+    if (i == 0 && rand_int(100) <= options->at(Option::PRIMARY_KEY)->getInt()) {
       type = Column::INT;
       name = "pkey";
       col = new Column{name, this, type};


### PR DESCRIPTION
pstress-122 pstress option --primary-key-probability 100 does not ensure tables
have PK after drop+create table
https://jira.percona.com/browse/PSTRESS-122

Fixed the corner case of not creating table with pkey