### PR TITLE
PSTRESS-138: Crashes caused by dangling pointers

### DIFF
--- a/pstress/pstress-run.sh
+++ b/pstress/pstress-run.sh
@@ -148,11 +148,11 @@ if [ "$(whoami)" == "root" ]; then MYEXTRA="--user=root ${MYEXTRA}"; fi
 if [ "${PXC_CLUSTER_RUN}" == "1" ]; then
   echoit "As PXC_CLUSTER_RUN=1, this script is auto-assuming this is a PXC run and will set PXC=1"
   PXC=1
-  THREADS=$(cat ${PXC_CLUSTER_CONFIG} | grep threads | head -n1 | sed 's/.*=//' | sed 's/^ *//g')
+  THREADS=$(cat ${PXC_CLUSTER_CONFIG} | grep ^threads | head -n1 | sed 's/.*=//' | sed 's/^ *//g')
 elif [ "${GRP_RPL_CLUSTER_RUN}" == "1" ]; then
   echoit "As GRP_RPL_CLUSTER_RUN=1, this script is auto-assuming this is a Group Replication run and will set GRP_RPL=1"
   GRP_RPL=1
-  THREADS=$(cat ${GR_CLUSTER_CONFIG} | grep threads | grep -v "#" | head -n1 | sed 's/.*=//' | sed 's/^ *//g')
+  THREADS=$(cat ${GR_CLUSTER_CONFIG} | grep ^threads | grep -v "#" | head -n1 | sed 's/.*=//' | sed 's/^ *//g')
 fi
 if [ "${PXC}" == "1" ]; then
   if [ ${QUERIES_PER_THREAD} -lt 2147483647 ]; then  # Starting up a cluster takes more time, so don't rotate too quickly

--- a/src/random_test.hpp
+++ b/src/random_test.hpp
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <vector>
 #include <writer.h>
+#include <memory>
 #define INNODB_16K_PAGE_SIZE 16
 #define INNODB_8K_PAGE_SIZE 8
 #define INNODB_32K_PAGE_SIZE 32
@@ -162,7 +163,7 @@ struct Thd1 {
   MYSQL *conn;
   std::atomic<unsigned long long> &performed_queries_total;
   std::atomic<unsigned long long> &failed_queries_total;
-  MYSQL_RES *result;          // result set of sql
+  std::shared_ptr<MYSQL_RES> result;          // result set of sql
   bool ddl_query = false;     // is the query ddl
   bool success = false;       // if the sql is successfully executed
   bool store_result = false;  // store result of executed sql


### PR DESCRIPTION
access, out of bound array access

https://jira.percona.com/browse/PSTRESS-138

Fixed problems:
1. usage of the pointer pointing to deallocated MYSQL_RES (get_result() and execute_sql() functions)
2. out of bound array indexing in case of the result having fewer fields than expected
3. Uncaught exceptions thrown by thread routine
4. Wrong parsing of the config file in case of PXC_CLUSTER_RUN=1