### PR TITLE
PSTRESS-148: pstress --help shows invalid arguments

### DIFF
--- a/src/help.cpp
+++ b/src/help.cpp
@@ -820,15 +820,6 @@ void show_help(std::string help) {
 
   void show_help() {
     print_version();
-    std::cout << " - pstress supports two different use/configuration modes; "
-                 "commandline or INI-file. Please see specific help:"
-              << std::endl;
-    std::cout << "=> pstress --config-help for INI-config help, this mode "
-                 "supports SINGLE and MULTIPLE node(s)"
-              << std::endl;
-    std::cout << "=> pstress --cli-help for commandline options, this mode "
-                 "supports a SINGLE node only"
-              << std::endl;
     std::cout << " - For complete help use => pstress  --help --verbose"
               << std::endl;
     std::cout << " - For help on any option => pstress --help=OPTION e.g. \n "


### PR DESCRIPTION
https://jira.percona.com/browse/PSTRESS-148

pstress' --help option shows pquery's --config-help and --cli-help options, which are not supported by pstress. So, this has been removed from the help text.