### PR TITLE
PSTRESS-147 The --log-query-duration option must be enabled by default

### DIFF
--- a/src/help.cpp
+++ b/src/help.cpp
@@ -677,7 +677,7 @@ void add_options() {
   opt =
       newOption(Option::BOOL, Option::LOG_QUERY_DURATION, "log-query-duration");
   opt->help = "Log query duration in milliseconds";
-  opt->setBool(false);
+  opt->setBool(true);
   opt->setArgs(no_argument);
 
   /* log failed queries */


### PR DESCRIPTION
https://jira.percona.com/browse/PSTRESS-147