### PR TITLE
PSTRESS-160: Add support for ASan testing and gdb

### DIFF
--- a/pstress/pstress-run-rocksdb-asan.conf
+++ b/pstress/pstress-run-rocksdb-asan.conf
@@ -1,27 +1,39 @@
 #!/bin/bash
-# Created by Mohit Joshi, Percona LLC
-
-################################################################################
-# Welcome to the pstress configuration file for RocksDB                        #
-# (pstress-run-rocksdb.conf). Feel free to copy this file, edit the copy &     #
-# change the CONFIGURATION_FILE variable in pstress-run.sh to match!           #
-#                                                                              #
-# Please do not change this file unless your name is listed above. As a        #
-# template/default, it is the only configuration file for pstress which        #
-# is maintained whenever pstress-run.sh is updated.                            #
-################################################################################
 
 # ################### User configurable variables: generics 1 ##################
 # pstress-ps: Percona Server, pstress-ms: MySQL, pstress-pxc: PXC              #
 ################################################################################
-PSTRESS_BIN=${SCRIPT_PWD}/../src/pstress-ps
+MYWORKSPACE=/data/pstress-run
+# pstress-ps: Percona Server, pstress-ms: MySQL, pstress-pxc: PXC
+PSTRESS_BIN=${MYWORKSPACE}/build/src/pstress-ps
+# Working directory. Here we keep the log files, option list, failed items.
+WORKDIR=${MYWORKSPACE}/workdir/$RANDOMD
+# Run directory. Keeps a copy of the data dir template & stores mysqld runs
+RUNDIR=${MYWORKSPACE}/rundir/$RANDOMD
+# MySQL Basedir.
+BASEDIR=/data/mysql-server/percona-8.0-deb-gcc14-rocks-asan-install
 
 ################################################################################
 # Options for pstress used to define the type of DDLs/DMLs/SQLs to be          #
 # executed. Default options added.                                             #
 # Please modify the parameters as per needs before starting the runs.          #
 ################################################################################
-DYNAMIC_QUERY_PARAMETER="--tables 10 --records 100 --log-all-queries"
+#DYNAMIC_QUERY_PARAMETER="--tables 10 --records 100 --log-all-queries"
+#DYNAMIC_QUERY_PARAMETER="--no-partition-tables --tables 16 --records 1000 --log-all-queries"
+DYNAMIC_QUERY_PARAMETER="--tables 16 --records 1000 --log-all-queries"
+
+GDB_MODE=0
+LIBASAN_SO=$(ldconfig -p | grep libasan.so | sort -V | tail -1 | awk '{print $NF}')
+
+if [ $GDB_MODE -eq 1 ]; then
+    #export ASAN_OPTIONS=detect_leaks=1:log_path=asan_log:symbolize=1:abort_on_error=1:detect_odr_violation=2
+    INLINE_ENV_VARS="env LD_PRELOAD=${LIBASAN_SO} ASAN_OPTIONS=abort_on_error=1"
+    SIGNAL=15
+else
+    INLINE_ENV_VARS="env LD_PRELOAD=${LIBASAN_SO} ASAN_OPTIONS=log_path=${MYWORKSPACE}/asan.log"
+    SIGNAL=9
+fi
+
 
 ################################################################################
 # Empty seed implies Random seed number (6 digit no.) will be chosen by driver #
@@ -55,42 +67,11 @@ ADD_RANDOM_ROCKSDB_OPTIONS=1
 MAX_NR_OF_RND_OPTS_TO_ADD=4
 
 ################################################################################
-# MySQL Basedir. Required for all runs, including PXC                          #
-# eg. BASEDIR=$HOME/mysql-8.0/bld/install                                      #
-################################################################################
-BASEDIR=$HOME/path/to/PS/bld/directory
-
-################################################################################
-# Working directory. Here we keep the log files, option list, failed items.    #
-# Please leave $RANDOMD!                                                       #
-################################################################################
-WORKDIR=$HOME/create/a/directory/$RANDOMD
-
-################################################################################
-# Run directory. Keeps a copy of the data dir template & stores mysqld runs    #
-# (--datadir=x). Pls leave $RANDOMD!                                           #
-################################################################################
-RUNDIR=/tmp/$RANDOMD
-
-################################################################################
 # Number of threads to use. Default: 1. Set to >1 to enable multi-threaded     #
 # runs.                                                                        #
 ################################################################################
-THREADS=10
-
-################################################################################
-# The option is used to stop the server in different ways                      #
-# for ex -                                                                     #
-# SIGNAL=15    => This will perform a normal shutdown                          #
-# SIGNAL=9     => This will kill the server with SIG9(kill -9) only            #
-# SIGNAL=4     => This will kill the server with SIG4(kill -4) only            #
-#                                                                              #
-# Default : SIGNAL=9                                                           #
-#                                                                              #
-# Note: Any other value passed apart from above listed will be invalid and     #
-# result in terminating pstress                                                #
-################################################################################
-SIGNAL=9
+#THREADS=10
+THREADS=4
 
 ################################################################################
 # Number of individual trials to execute (one can always interrupt with ctrl+c #

--- a/pstress/pstress-run.sh
+++ b/pstress/pstress-run.sh
@@ -499,7 +499,7 @@ if [ -r ${BASEDIR}/bin/mysqld ]; then
   BIN=${BASEDIR}/bin/mysqld
 else
   # Check if this is a debug build by checking if debug string is present in dirname
-  if [[ ${BASEDIR} = *debug* ]]; then
+  if [[ "$BASEDIR" == *debug* || "$BASEDIR" == *-deb-* ]]; then
     if [ -r ${BASEDIR}/bin/mysqld-debug ]; then
       BIN=${BASEDIR}/bin/mysqld-debug
     else


### PR DESCRIPTION
1. Introduce `pstress/pstress-run-rocksdb-asan.conf`
2. Add support for `INLINE_ENV_VARS` param for setting `LD_PRELOAD` and `ASAN_OPTIONS`
3. Add support for `GDB_MODE` param
