### PR TITLE
PSTRESS-162: Fix issues with pstress-run.sh

### DIFF
--- a/pstress/pstress-run.sh
+++ b/pstress/pstress-run.sh
@@ -70,7 +70,11 @@ if [ ! -r ${PSTRESS_BIN} ]; then echo "${PSTRESS_BIN} specified in the configura
 if [ ! -r ${OPTIONS_INFILE} ]; then echo "${OPTIONS_INFILE} specified in the configuration file used (${SCRIPT_PWD}/${CONFIGURATION_FILE}) cannot be found/read"; exit 1; fi
 
 # Try and raise ulimit for user processes (see setup_server.sh for how to set correct soft/hard nproc settings in limits.conf)
-ulimit -u 7000
+current_limit=$(ulimit -u)
+if [ "$current_limit" -lt 7000 ]; then
+  echo "Current ulimit -u is $current_limit, raising to 7000"
+  ulimit -u 7000
+fi
 
 #Format version string (thanks to wsrep_sst_xtrabackup-v2) 
 normalize_version(){


### PR DESCRIPTION
1. Set `ulimit -u 7000` only if current limit is lower than 7000
2. Fix support for `mysqld-debug` (instead of `mysqld` only):
a) replace `${BASEDIR}/bin/mysqld` with `${MYSQLD_BIN}`
b) rename `${BIN}` to `${MYSQLD_BIN}`
