### PR TITLE
PSTRESS-162: Fix wrong interpretation of `mysql_real_query()` results in pstress

### DIFF
--- a/pstress/pstress_log_to_sql_converter.sh
+++ b/pstress/pstress_log_to_sql_converter.sh
@@ -110,7 +110,7 @@ sed -i 's/rows:[0-9]*//g' $OUTPUT_FILENAME
 crashQuery=$(awk '/Error Lost connection to MySQL server during query/{print prev} {prev=$0}' $LOG_FILENAME | head -n1 | sed 's/.* F //')
 
 # Append the crashing query at the end of output file
-echo $crashQuery >> $OUTPUT_FILENAME
+echo "$crashQuery" >> $OUTPUT_FILENAME
 
 # Adding semi-colon at the end of each SQL statement. In case, semi-colon
 # already exists, then do not add twice

--- a/src/random_test.cpp
+++ b/src/random_test.cpp
@@ -1907,7 +1907,7 @@ bool execute_sql(const std::string &sql, Thd1 *thd) {
   }
   thd->performed_queries_total++;
 
-  if (res == 1) { // query failed
+  if (res != 0) { // query failed
     thd->failed_queries_total++;
     thd->max_con_fail_count++;
     if (log_all || log_failed) {
@@ -1916,7 +1916,7 @@ bool execute_sql(const std::string &sql, Thd1 *thd) {
     }
     if (mysql_errno(thd->conn) == CR_SERVER_GONE_ERROR ||
         mysql_errno(thd->conn) == CR_SERVER_LOST) {
-      thd->thread_log << "server gone, while processing " + sql;
+      thd->thread_log << "server gone, while processing " + sql << std::endl;
       run_query_failed = true;
     }
   } else {


### PR DESCRIPTION
1. `mysql_real_query()` returns: `Zero for success. Nonzero if an error occurred.`
2. Add missing brackets in `pstress_log_to_sql_converter.sh`