### PR TITLE
Updated exclude_patterns to exclude reporting existing issues.

### DIFF
--- a/pstress/exclude_patterns.txt
+++ b/pstress/exclude_patterns.txt
@@ -18,18 +18,15 @@
 ############################################################################################
 
 # Error reported by Mysqlx plugin when the socket is not free.
-.*\\[Server\\].*Plugin mysqlx reported.*
+.*\[Server\].*Plugin mysqlx reported.*
 
 # Error reported by InnoDB when an active undo tablespace is dropped.
 .*Cannot drop undo tablespace.*
 
-# PS-6848
-.*Assertion failure.*fsp0fsp.cc.*encryption_op_in_progress.*
-
-# PS-6847
+# PS-6847 : legacy issue closed without fix. If noticed again report new bug.
 .*Assertion failure.*btr0btr.ic:.*level.*
 
-# PS-7148
+# PS-7148 : legacy issue closed without fix. If noticed again report new bug.
 .*buf0buf.cc.*buf_pool.*init_flush.*
 
 # PS-7663
@@ -72,7 +69,13 @@
 .*Error_code: 1488.*
 .*Error_code: 1176.*
 
-# PS-7865 Dropping a table with discarded tablespace crashes the server.
-.*Assertion failure.*btr0sea.cc:.*page.id.space.*
+.*\[MY-012585\].*Linux Native AIO interface.*
 
-.*[MY-012585].*Linux Native AIO interface.*
+# PXC-4556
+.*Assertion.*state\(\) == s_certifying.*
+
+# PXC-4549
+.*Assertion.*state\(\) == s_aborting \|\| state\(\) == s_must_replay.*
+
+# PXC-4491
+.*Assertion.*state\(\) == s_executing \|\| state\(\) == s_preparing \|\| state\(\) == s_prepared \|\| state\(\) == s_must_abort \|\| state\(\) == s_aborting \|\| state\(\) == s_cert_failed \|\| state\(\) == s_must_replay.*

--- a/pstress/exclude_patterns_57.txt
+++ b/pstress/exclude_patterns_57.txt
@@ -1,0 +1,70 @@
+############################################################################################                                                            #
+# Note:                                                                                    #
+# (1). This file is used by search_string.sh along with exclude_patterns.txt to exclude    #
+#      issues related to 5.7 version which doesn't exist on other versions.                #
+# (2). The file contains list of regular expressions to tag a particular error.            #
+# (3). Any known crash/error can be included in this file with a unique signature (regex)  #
+# (4). Line starting with a (#) will be treated as a comment & shall be ignored            #
+#                                                                                          #
+# How to use:                                                                              #
+# (1). Add a comment with the Bug# and tag it against the signature                        #
+# (2). Do not write anything after the signature                                           #
+#                                                                                          #
+# For ex:                                                                                  #
+#        # PS-6848                                                                         #
+#        Assertion failure.*fsp0fsp.cc.*encryption_op_in_progress                          #
+############################################################################################
+
+# PS-6848
+.*Assertion failure.*fsp0fsp.cc.*encryption_op_in_progress.*
+
+# PS-7865 Dropping a table with discarded tablespace crashes the server.
+.*Assertion failure.*btr0sea.cc:.*page.id.space.*
+
+.*In ALTER TABLE `test`.`tt_4_fk` has or is referenced in foreign key constraints which are not compatible with the new table definition.*
+.*InnoDB: Flagged corruption of.*in table .* in CHECK TABLE; Wrong count.*
+.*Got error 180 when reading table.*
+.*InnoDB: Table .* contains .* indexes inside InnoDB, which is different from the number of indexes .* defined in MySQL.*
+.*InnoDB: Table .* does not exist in the InnoDB internal data dictionary though MySQL is trying to drop it. Have you copied the .frm file of the table to the MySQL database directory from another database\?.*
+.*InnoDB: Cannot create file .*
+.*InnoDB: The file .* already exists though the corresponding table did not exist in the InnoDB data dictionary. Have you moved InnoDB .ibd files around without using the SQL commands DISCARD TABLESPACE and IMPORT TABLESPACE, or did mysqld crash in the middle of CREATE TABLE\? You can resolve the problem by removing the file .* under the.*datadir.*of MySQL.*
+.*Cannot find index .* in InnoDB index dictionary.*
+.*Build InnoDB index translation table for Table .* failed.*
+.*InnoDB could not find key no .* with name .* from dict cache for table .*
+.*Table .* contains fewer indexes inside InnoDB than are defined in the MySQL .frm file. Have you mixed up .frm files from different installations.*
+.*InnoDB: Index .* of table .* is corrupted.*
+.*InnoDB: Cannot delete tablespace .* because it is not found in the tablespace memory cache.*
+.*Cannot find index .* in InnoDB index dictionary.*
+.*Build InnoDB index translation table for Table .* failed.*
+.*InnoDB could not find key no .* with name .* from dict cache for table .*
+.*Table .* contains fewer indexes inside InnoDB than are defined in the MySQL .frm file. Have you mixed up .frm files from different installations.*
+
+.*Failing assertion:.*table->n_foreign_key_checks_running.*==.*0.*
+
+.*handler0alter.cc:.*:.*virtual.*bool.*ha_innobase::commit_inplace_alter_table\(TABLE\*, Alter_inplace_info\*, bool\):.*Assertion.*!index->to_be_dropped.*
+
+.*handler0alter.cc:.*:.*bool.*rollback_inplace_alter_table\(Alter_inplace_info\*, const TABLE\*, row_prebuilt_t\*\):.*Assertion.*!clust_index->online_log.*
+
+# PXC-4301 in file ha_innodb.cc line 5571
+.*InnoDB:.*Failing assertion:.*!ut_strcmp\(name, field->field_name\).*
+
+# https://github.com/percona/percona-server/pull/4587
+.*ha_innodb.cc:.*:.*void.*ha_innobase::update_thd\(THD\*\):.*Assertion.*m_prebuilt->table->n_ref_count > 0.*
+
+
+# PS-5943 in file ha_innodb.cc line 20752
+.*InnoDB:.*Failing assertion:.*!ret.*
+
+# PS-5658 in file btr0sea.cc line 1570
+.*InnoDB:.*Failing assertion:.*os_atomic_increment_ulint\(&\(block\)->n_pointers, 0\).*==.*0.*
+
+# PS-8003 in file buf0buf.cc line 3101
+.*InnoDB:.*Failing assertion:.*buf_block_get_state\(block\).*==.*BUF_BLOCK_FILE_PAGE.*
+
+# PS-5781
+.*\[FATAL\].*InnoDB:.*Missing.*MLOG_FILE_NAME.*or.*MLOG_FILE_DELETE.*for.*redo.*log.*record.*
+.*InnoDB:.*Assertion failure in thread .* in file ut0ut.cc.*
+
+# PS-8002
+.*sql/field.cc:.*:.*virtual.*longlong.*Field_long::val_int\(\):.*Assertion.*!table \|\| \(!table->read_set \|\| bitmap_is_set\(table->read_set, field_index\)\).*
+.*sql/field.cc:.*:.*virtual.*String.*Field_float::val_str\(String\*, String\*\): Assertion.*!table \|\| \(!table->read_set \|\| bitmap_is_set\(table->read_set, field_index\)\).*

--- a/pstress/exclude_patterns_9.txt
+++ b/pstress/exclude_patterns_9.txt
@@ -1,0 +1,19 @@
+############################################################################################                                                       #
+# Note:                                                                                    #
+# (1). This file is used by search_string.sh along with exclude_patterns.txt to exclude    #
+#      issues related to 9.x version which doesn't exist on other versions.                #
+# (2). The file contains list of regular expressions to tag a particular error.            #
+# (3). Any known crash/error can be included in this file with a unique signature (regex)  #
+# (4). Line starting with a (#) will be treated as a comment & shall be ignored            #
+#                                                                                          #
+# How to use:                                                                              #
+# (1). Add a comment with the Bug# and tag it against the signature                        #
+# (2). Do not write anything after the signature                                           #
+#                                                                                          #
+# For ex:                                                                                  #
+#        # PS-6848                                                                         #
+#        Assertion failure.*fsp0fsp.cc.*encryption_op_in_progress                          #
+############################################################################################
+
+# PS-11023
+.*handler::ha_index_end\(\):.*Assertion.*inited.*==.*INDEX.*

--- a/pstress/search_string.sh
+++ b/pstress/search_string.sh
@@ -20,11 +20,25 @@ if [ "$ERROR_LOG" == "" ]; then
   fi
 fi
 
+VERSION=$(grep -m1 -oE 'mysqld [0-9]+\.[0-9]+(\.[0-9]+)?' "$ERROR_LOG" | awk '{print $2}')
+
 ASSERTION_FLAG=0;
 ERROR_FLAG=0;
 SEARCH_ERROR_PATTERN="\[ERROR\].*"
 SEARCH_ASSERT_PATTERN="Assertion failure:|Failing assertion:|Assertion.*failed|mysqld got signal 11";
 SEARCH_FILE=exclude_patterns.txt
+
+if [[ "$VERSION" == 5.7* ]]; then
+  VERSION_SEARCH_FILE=exclude_patterns_57.txt
+elif [[ "$VERSION" == 9.* ]]; then
+  VERSION_SEARCH_FILE=exclude_patterns_9.txt
+fi
+
+if [[ -n "$VERSION_SEARCH_FILE" ]]; then
+  SEARCH_FILE=$(mktemp)
+  trap 'rm -f "$SEARCH_FILE"' EXIT
+  cat exclude_patterns.txt "$VERSION_SEARCH_FILE" > "$SEARCH_FILE"
+fi
 
 # Search assertion string in Error log
 PATTERN=$(egrep "$SEARCH_ASSERT_PATTERN" $ERROR_LOG |
@@ -57,12 +71,16 @@ if [ $ASSERTION_FLAG -eq 1 ]; then
       do
         if [[ $line =~ ${SigTag} ]]; then
           echo "Known Bug reported in JIRA found. Please check the Bug status for more details";
-          egrep -B1 "${SigTag}" $SEARCH_FILE
+          echo "$sigtag_prior_line"
+          echo "$line"
           ASSERT_FOUND=1
           break;
-      fi
-    done < <(egrep -v '^#|^$' $SEARCH_FILE)
+        else
+          sigtag_prior_line=${SigTag}
+        fi
+    done < <(grep -v '^$' $SEARCH_FILE)
   if [[ $ASSERT_FOUND -eq 0 ]]; then
+    echo "New Assertion/Crash found in error log(s). Potentially a Bug, please investigate";
     echo "$line"
   fi
   done < <(printf '%s\n' "$ASSERT_STRING")


### PR DESCRIPTION
Updated the exclude_patterns.txt by removing fixed issues and adding new issues. Added new exclude_patterns files for 57 and 9 versions to ignore existing issues based on version. Added exclude_patterns files for 57 and 9 versions. Updated search_string.sh to consider issues from new version specific exclude_patterns files.